### PR TITLE
fix: upgrade Knot iOS SDK

### DIFF
--- a/react-native-knotapi.podspec
+++ b/react-native-knotapi.podspec
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,mm}"
 
   s.dependency "React-Core"
-  s.dependency 'KnotAPI', '~> 0.1.38'
+  s.dependency 'KnotAPI', '~> 0.1.39'
 
 
   # Don't install the dependencies when we run `pod install` in the old architecture.


### PR DESCRIPTION
This commit upgrades the Knot iOS SDK from 0.1.38 to 0.1.39 to fix an issue with lottie files