### PR TITLE
Fix `noEvent` parameters

### DIFF
--- a/ios/Knotapi.mm
+++ b/ios/Knotapi.mm
@@ -71,8 +71,12 @@ RCT_EXPORT_METHOD(openCardSwitcher:(NSDictionary *)params){
       [config setOnSuccessOnSuccess:^(NSString *merchant) {
           [self sendEventWithName:@"CardSwitcher-onSuccess" body:@{@"merchant": merchant}];
       }];
-      [config setOnEventOnEvent:^(NSString * event, NSString * message) {
-          [self sendEventWithName:@"CardSwitcher-onEvent" body:@{@"event": event, @"merchant": message}];
+      [config setOnEventOnEvent:^(NSString * _Nonnull event, NSString * _Nonnull message, NSString * _Nullable task_id) {
+          NSMutableDictionary *body = [@{@"event": event, @"merchant": message} mutableCopy];
+          if (task_id != nil) {
+              body[@"task_id"] = task_id;
+          }
+          [self sendEventWithName:@"CardSwitcher-onEvent" body:body];
       }];
       [config setOnErrorOnError:^(NSString * error, NSString * message) {
           [self sendEventWithName:@"CardSwitcher-onError" body:@{@"errorCode": error, @"errorMessage": message }];


### PR DESCRIPTION
Currently the app is failing to build with an error:
```
Knotapi.mm:74:33 Cannot initialize a parameter of type 'void (^ _Nonnull)(NSString * _Nonnull __strong, NSString * _Nonnull __strong, NSString * _Nullable __strong)' with an rvalue of type 'void (^)(NSString *__strong, NSString *__strong)
```
This PR adds the missing third nullable parameter to the method.
Probably, it's not the correct way to add it, but at least illustrates the problem.